### PR TITLE
Feature customize ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-examples:=ex1 ex2 ex3 ex4 ex5
+examples:=ex1 ex2 ex3 ex4 ex5 ex6
 all:: unit $(examples)
 
 test-src:=unit.cc test_failure.cc test_utility.cc test_reader.cc
@@ -19,8 +19,8 @@ vpath %.cc $(top)test
 vpath %.cc $(top)ex
 
 CXXSTD?=c++17
-#OPTFLAGS?=-O2 -fsanitize=address -march=native
-OPTFLAGS?=-march=native
+OPTFLAGS?=-O2 -march=native
+#OPTFLAGS?=-fsanitize=address -march=native
 CXXFLAGS+=$(OPTFLAGS) -MMD -MP -std=$(CXXSTD) -pedantic -Wall -Wextra -g -pthread
 CPPFLAGS+=-isystem $(gtest-inc) -I $(top)include
 
@@ -48,6 +48,9 @@ ex4: ex4.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 ex5: ex5.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+ex6: ex6.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 clean:

--- a/TODO
+++ b/TODO
@@ -10,17 +10,16 @@ Also: should we copy in the backport::exception unit tests?
 
 ### Support for writing to members of subobjects
 
-Without direct support for C++ pointers to members of
-subobjects or ptm arithmetic, writing parameter values
-to members of a subobject will require explicit support
-in the API. One approach is to replace pointer-to-members
-with more general setter (and possibly getter) functions
-which can be constructed from e.g. a chain of ptms.
+This is currently provided by delegating specifications
+for a subobject of a field to specifications defined for
+that field.
 
-Alternatively or in addition, add support for delegating
-a parameter specification for a field of a subobject of type Q
-in a struct of type P to an exisiting parameter specification
-for type Q.
+Possibility of adding mechanism for direct access to
+subobject members remains, but that might rely upon an
+implementation that relies upon implementation-defined
+behaviour (or even in theory UB if not in practice) due
+to some lacunae in the C++ spec regarding object
+representations.
 
 ### Expand library of supplied read/write functions
 
@@ -48,6 +47,11 @@ constructing them. Should they be permitted? If so, document
 and provide support and helper functions for them. If not,
 remove support and consequently simplify the specification class
 and API.
+
+### More validators
+
+Supply a few more simple validators, and maybe change the names
+of existing ones to be clearer.
 
 ## Medium priority
 
@@ -94,6 +98,9 @@ another other contexts where UCS-2 or UCS-4 representations might
 be used. Take the current std::sting_view/std::string represenations
 and substitute std::basic_string_view/std::basic_string, propagating
 CharT and Traits?
+
+Also can consider unicode normalisation as a canonicalization option
+for specification_set.
 
 ### Closer integration with tinyopt
 

--- a/ex/ex5.cc
+++ b/ex/ex5.cc
@@ -16,9 +16,8 @@ namespace P = parapara;
 const char* ini_text =
     "# Validators require odd values in [odd] and even values in [even]\n"
     "\n"
-    "flag = true\n"
-    "\n";
-#if 0
+    "   flag  \n"
+    "\n"
     "# Section heading without ']' should give bad_syntax error\n"
     "[oops\n"
     "\n"
@@ -33,8 +32,6 @@ const char* ini_text =
     "a = 3\n"
     "b = 4\n"
     "c = 5\n";
-
-#endif
 
 int main(int, char**) {
     struct abc {
@@ -67,22 +64,20 @@ int main(int, char**) {
     } p;
 
     std::vector<P::specification<params>> specs = {
-        {"flag", &params::flag}
+        P::specification<params>("flag", &params::flag, [](bool v) { return v; }, "Some description")
     };
 
-#if 0
     for (const auto& s: abc_odd) {
         specs.emplace_back("odd/"+s.key, &params::odd, s);
     }
     for (const auto& s: abc_even) {
         specs.emplace_back("even/"+s.key, &params::even, s);
     }
-#endif
+
     P::source_context ctx;
     ctx.source = "ini_text";
     std::stringstream in(ini_text);
 
-#if 0
     P::specification_set spec_set(specs);
     P::ini_importer importer{in, ctx};
     while (importer) {
@@ -94,8 +89,6 @@ int main(int, char**) {
             std::cout << P::explain(h.error(), true) << '\n';
         }
     }
-#endif
-    specs[0].read(p, "true");
 
     std::cout << "Record values by key:\n";
     for (const auto& s: specs) {

--- a/ex/ex6.cc
+++ b/ex/ex6.cc
@@ -183,6 +183,7 @@ int main(int, char**) {
     struct params {
         int a = 0;
         std::string b;
+        bool top = false;
         int top_a = 0;
         int top_sub_a = 0;
         int top_sub_subsub_a = 0;
@@ -192,6 +193,7 @@ int main(int, char**) {
     P::specification<params> specs[] = {
         {"a", &params::a},
         {"b", &params::b},
+        {"top", &params::top},
         {"top/a", &params::top_a},
         {"top/sub/a", &params::top_sub_a},
         {"top/sub/subsub/a", &params::top_sub_subsub_a},

--- a/ex/ex6.cc
+++ b/ex/ex6.cc
@@ -1,0 +1,212 @@
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <parapara/parapara.h>
+
+using namespace std::literals;
+
+namespace P = parapara;
+
+// Demo for alternative INI-like syntax, using custom_ini_parser defined below
+// instead of parapara::simple_ini_parser.
+
+const char* ini_text =
+    "// Comments introduced with //\n"
+    " a = 3   // Comments can come at end\n"
+    " b = 'fish // bar' // Values can be optionally quoted\n"
+    "\n"
+    "[top]\n"
+    " a = 1\n"
+    "[./sub] // Can finangle 'relative' section names\n"
+    " a = 2\n"
+    "[./subsub]\n"
+    " a = 3\n"
+    "[../../sub2]\n"
+    " a = 4\n";
+
+// Custom ini parser:
+// * Comments are introduced with // and can follow a key assignment
+// * Values in key assignment can optionally be quoted with '
+
+using P::ini_record;
+using P::ini_record_kind;
+
+ini_record custom_ini_parser(std::string_view v) {
+    using token = ini_record::token;
+    using size_type = std::string_view::size_type;
+
+    constexpr size_type npos = std::string_view::npos;
+    constexpr std::string_view ws{" \t\f\v\r\n"};
+
+    auto comment_at = [](std::string_view v, size_type p) { return v.substr(p, 2)=="//"; };
+    size_type b = v.find_first_not_of(ws);
+
+    // empty or comment?
+    if (b==npos || comment_at(v, b)) return ini_record{ini_record_kind::empty};
+
+    // section heading?
+    if (v[b]=='[') {
+        size_type e = v.find(']');
+
+        // check for malformed heading
+        if (e==npos) return {ini_record_kind::syntax_error, token("", b+1)};
+
+        if (e+1<v.length()) {
+            auto epilogue = v.find_first_not_of(ws, e+1);
+            if (epilogue!=npos && !comment_at(v, epilogue)) {
+                return {ini_record_kind::syntax_error, token("", epilogue)};
+            }
+        }
+
+        b = v.find_first_not_of(ws, b+1);
+        e = v.find_last_not_of(ws, e-1);
+
+        return {ini_record_kind::section, token(v.substr(b, e>=b? e+1-b: 0), b+1)};
+    }
+
+    // expect key first, followed by ws and eol, =, or //.
+    size_type j = std::min(v.find('=', b), v.find("//", b));
+    token key_token{v.substr(b, j==b? 0: v.find_last_not_of(ws, j-1)+1-b), b+1};
+
+    // key without value?
+    if (j==npos || v[j]!='=') {
+        return {ini_record_kind::key, key_token};
+    }
+
+    // skip to text after =, look for value
+    size_type eq = j;
+    size_type value_cindex = eq;
+
+    if (j<v.length()) {
+        j = v.find_first_not_of(ws, j+1);
+        if (j!=npos && !comment_at(v, j)) {
+            value_cindex = j+1;
+
+            // if value is not quoted, take text up to eol or first eol, discarding trailing ws
+            if (v[j]!='\'') {
+                size_type end = v.find("//", j);
+                if (end!=npos) --end;
+
+                return {ini_record_kind::key_value, key_token,
+                        token{v.substr(j, v.find_last_not_of(ws, end)-j+1), value_cindex}};
+            }
+            else {
+                // quoted value; take until next unescaped '
+                std::string value;
+                size_type epilogue = npos;
+                bool esc = false;
+
+                for (size_type i = j+1; i<v.length(); ++i) {
+                    if (esc) {
+                        value += v[i];
+                        esc = false;
+                    }
+                    else if (v[i]=='\'') {
+                        epilogue = i+1;
+                        break;
+                    }
+                    else if (v[i]=='\\') {
+                        esc = true;
+                    }
+                    else {
+                        value += v[i];
+                    }
+                }
+
+                // unterminated quoted value or escaped eol?
+                if (epilogue==npos || esc) {
+                    return {ini_record_kind::syntax_error, token("", j)};
+                }
+
+                // extra stuff following value that is not a comment?
+                if (epilogue<v.length()) {
+                    epilogue = v.find_first_not_of(ws, epilogue);
+                    if (epilogue!=npos && !comment_at(v, epilogue)) {
+                        return {ini_record_kind::syntax_error, token("", epilogue)};
+                    }
+                }
+
+                return {ini_record_kind::key_value, key_token, token{value, value_cindex}};
+            }
+        }
+    }
+    // key with empty value
+    return {ini_record_kind::key_value, key_token, token{"", eq}};
+}
+
+// Use a custom line-by-line ini importer to handle relative section headings
+template <typename Record>
+P::hopefully<void> custom_import_ini(Record& rec, const P::specification_set<Record>& specs, std::istream& in)
+{
+    constexpr auto npos = std::string_view::npos;
+
+    P::ini_style_importer importer(custom_ini_parser, in);
+    while (importer) {
+        std::string prev_sec{importer.section()};
+        auto h = importer.run_one(rec, specs, P::default_reader(), "/");
+
+        if (!h) {
+            std::cout << P::explain(h.error(), true) << '\n';
+            continue;
+        }
+
+        if (h.value() != P::ini_record_kind::section) continue;
+
+        std::string_view new_sec = importer.section();
+        if (new_sec.substr(0, 2)=="./") {
+            std::string section{prev_sec};
+            section += new_sec.substr(1);
+            importer.section(section);
+        }
+        else if (new_sec.substr(0, 3)=="../") {
+            std::string_view prefix(prev_sec);
+            do {
+                new_sec.remove_prefix(3);
+                if (auto tail = prefix.rfind('/'); tail != npos) {
+                    prefix = prefix.substr(0, tail);
+                }
+            } while (new_sec.substr(0, 3)=="../");
+
+            std::string section{prefix};
+            section += "/";
+            section += new_sec;
+            importer.section(section);
+        }
+    }
+    return {};
+}
+
+int main(int, char**) {
+    struct params {
+        int a = 0;
+        std::string b;
+        int top_a = 0;
+        int top_sub_a = 0;
+        int top_sub_subsub_a = 0;
+        int top_sub2_a = 0;
+    } p;
+
+    P::specification<params> specs[] = {
+        {"a", &params::a},
+        {"b", &params::b},
+        {"top/a", &params::top_a},
+        {"top/sub/a", &params::top_sub_a},
+        {"top/sub/subsub/a", &params::top_sub_subsub_a},
+        {"top/sub2/a", &params::top_sub2_a}
+    };
+
+    P::source_context ctx;
+    ctx.source = "ini_text";
+    std::stringstream in(ini_text);
+
+    P::specification_set spec_set(specs);
+    custom_import_ini(p, spec_set, in);
+
+    std::cout << "Record values by key:\n";
+    for (const auto& s: specs) {
+        std::cout << s.key << '\t' << s.write(p).value() << '\n';
+    }
+}


### PR DESCRIPTION
* Restructure INI reader/parser to allow for customization points.
* Add demo in ex6.cc that emulates-ish GetPot usage in AMBiT.
* Set corresponding bool parameter in record to true on importing a section heading if there is a specification of that name in the provided set.