### PR TITLE
Rename specification_set to specification_map.

### DIFF
--- a/TODO
+++ b/TODO
@@ -10,15 +10,13 @@ Also: should we copy in the backport::exception unit tests?
 
 ### Support for writing to members of subobjects
 
-This is currently provided by delegating specifications
-for a subobject of a field to specifications defined for
-that field.
+This is currently provided by delegating specifications for a subobject
+of a field to specifications defined for that field.
 
-Possibility of adding mechanism for direct access to
-subobject members remains, but that might rely upon an
-implementation that relies upon implementation-defined
-behaviour (or even in theory UB if not in practice) due
-to some lacunae in the C++ spec regarding object
+Possibility of adding mechanism for direct access to subobject members
+remains, but that might rely upon an implementation that relies upon
+implementation-defined behaviour (or even in theory UB if not in
+practice) due to some lacunae in the C++ spec regarding object
 representations.
 
 ### Expand library of supplied read/write functions
@@ -28,44 +26,52 @@ explicitly or implicitly keyed sum types; pairs and tuples.
 
 ### Explicit handling of optional<X> fields
 
-Semantics for these fields is currently baked in. Is it better
-to treat them as regular values and delegate the representation
-responsibility to readers and writers?
+Semantics for these fields is currently baked in. Is it better to treat
+them as regular values and delegate the representation responsibility to
+readers and writers?
 
 There is currently no way to e.g. represent a field value of
-std::nullopt for such a field. For example, being able to
-have a parameter set by 'foo = default' or 'foo = nothing'
-may be desirable.
+std::nullopt for such a field. For example, being able to have a
+parameter set by 'foo = default' or 'foo = nothing' may be desirable.
 
-Perhaps some sort of fall-back process? i.e. use a specific
-optional<X> read function if present.
+Perhaps some sort of fall-back process? i.e. use a specific optional<X>
+read function if present.
+
+Proposed alternative to above: a `defaulted<T>` class designed to
+represent unset-value with fallback default values.
 
 ### Allow validators that modify the value?
 
 Currently they are accommodated, but there are no helper functions for
-constructing them. Should they be permitted? If so, document
-and provide support and helper functions for them. If not,
-remove support and consequently simplify the specification class
-and API.
+constructing them. Should they be permitted? If so, document and provide
+support and helper functions for them. If not, remove support and
+consequently simplify the specification class and API.
 
-### More validators
+### Handling of [section] in import, export
 
-Supply a few more simple validators, and maybe change the names
-of existing ones to be clearer.
+Sometimes may need to know if there is an emplicit but empty section;
+these can be represented e.g. by a specification for a field of type
+`parapara::section` that wraps bool.
+
+### Generic INI exporter
+
+INI style importer is generic, allowing more-or-less arbitrary INI-ish
+formats through an ini_record interface. Exporter should have sufficient
+facility to be able to do round trip import/export for these cases too.
 
 ## Medium priority
 
 ### Other representations
 
-Have at least a demo if not a supported implementation of using
-JSON objects (e.g. from nlohmann/json) as the external representation
-type, as opposed to std::string_view and std::string.
+Have at least a demo if not a supported implementation of using JSON
+objects (e.g. from nlohmann/json) as the external representation type,
+as opposed to std::string_view and std::string.
 
 ### Generalizing assignment
 
 Instead of always overwriting any fields in the parameter-storing
-structure, readers could instead do one of the following based on
-a per-parameter or per-parameter-set policy:
+structure, readers could instead do one of the following based on a
+per-parameter or per-parameter-set policy:
 
  * Replace (current default)
  * Replace default or ignore (if existing valus is default-constructed
@@ -78,14 +84,14 @@ reduction).
 
 ### Locale-aware vs locale-agnostic readers/writers
 
-Currently, deliberately using charconv for numeric represenations
-to avoid any locale dependencies and to get some round-trip gurarantees.
+Currently, deliberately using charconv for numeric represenations to
+avoid any locale dependencies and to get some round-trip gurarantees.
 Compare though with tinyopt, which deliberarely uses std::iostream
 formatted read/writes to reflect the user environment locale.
 
 Could supply a set of readers/writers based on these too, optionally
-with an explicit locale, giving applications an easy choice between
-the two.
+with an explicit locale, giving applications an easy choice between the
+two.
 
 ## Low priority
 

--- a/ex/ex2.cc
+++ b/ex/ex2.cc
@@ -28,10 +28,10 @@ int main(int, char** argv) {
     };
 
     auto munge = [](std::string_view s) -> std::string { return s=="quux"? "bar"s: std::string(s); };
-    P::specification_set specset(specs, munge);
+    P::specification_map spec_map(specs, munge);
 
     for (int i = 1; argv[i]; ++i) {
-        auto h = import_k_eq_v(p, specset, R, argv[i]);
+        auto h = import_k_eq_v(p, spec_map, R, argv[i]);
         if (!h) {
             parapara::failure f = h.error();
             f.ctx.source = "argv[" + std::to_string(i) + "]";

--- a/ex/ex3.cc
+++ b/ex/ex3.cc
@@ -55,10 +55,10 @@ int main(int, char**) {
         {"blurgle.quux", &params::quux, ""}
     };
 
-    P::specification_set specset(specs, parapara::keys_lc_nows);
+    P::specification_map spec_map(specs, parapara::keys_lc_nows);
 
     std::stringstream in(ini_text);
-    auto h = import_ini(p, specset, R, in, ".");
+    auto h = import_ini(p, spec_map, R, in, ".");
     if (!h) {
         h.error().ctx.source = "<ini_text>";
         std::cout << explain(h.error(), true) << "\n";

--- a/ex/ex4.cc
+++ b/ex/ex4.cc
@@ -51,7 +51,7 @@ int main(int, char**) {
 
     std::cout << "\nusing specification set:\n\n";
 
-    P::specification_set<params> S(specs);
+    P::specification_map<params> S(specs);
     P::writer W = P::default_writer();
 
     auto report = [&S, &W](const params& rec, const P::failure& error) {

--- a/ex/ex5.cc
+++ b/ex/ex5.cc
@@ -78,10 +78,10 @@ int main(int, char**) {
     ctx.source = "ini_text";
     std::stringstream in(ini_text);
 
-    P::specification_set spec_set(specs);
+    P::specification_map spec_map(specs);
     P::ini_importer importer{in, ctx};
     while (importer) {
-        auto h = importer.run_one(p, spec_set);
+        auto h = importer.run_one(p, spec_map);
         if (h && h.value()==P::ini_record_kind::section) {
             std::cout << "Checking section [" << importer.section() << "]\n";
         }

--- a/ex/ex6.cc
+++ b/ex/ex6.cc
@@ -139,7 +139,7 @@ ini_record custom_ini_parser(std::string_view v) {
 
 // Use a custom line-by-line ini importer to handle relative section headings
 template <typename Record>
-P::hopefully<void> custom_import_ini(Record& rec, const P::specification_set<Record>& specs, std::istream& in)
+P::hopefully<void> custom_import_ini(Record& rec, const P::specification_map<Record>& specs, std::istream& in)
 {
     constexpr auto npos = std::string_view::npos;
 
@@ -204,8 +204,8 @@ int main(int, char**) {
     ctx.source = "ini_text";
     std::stringstream in(ini_text);
 
-    P::specification_set spec_set(specs);
-    custom_import_ini(p, spec_set, in);
+    P::specification_map spec_map(specs);
+    custom_import_ini(p, spec_map, in);
 
     std::cout << "Record values by key:\n";
     for (const auto& s: specs) {

--- a/include/parapara/parapara.h
+++ b/include/parapara/parapara.h
@@ -1127,11 +1127,11 @@ std::vector<failure> validate(const Record& record, const C& specs) {
 // canonicalizer.
 
 template <typename Record>
-struct specification_set {
-    specification_set() = default;
+struct specification_map {
+    specification_map() = default;
 
     template <typename C, std::enable_if_t<std::is_assignable_v<specification<Record>&, value_type_t<C>>, int> = 0>
-    specification_set(const C& specs, std::function<std::string (std::string_view)> cify = {}):
+    specification_map(const C& specs, std::function<std::string (std::string_view)> cify = {}):
         canonicalize_(cify)
     {
         for (specification<Record> s: specs) insert(std::move(s));
@@ -1171,7 +1171,7 @@ struct specification_set {
         else return unrecognized_key(key);
     }
 
-    // Can also do the validation operation above from a specification_set.
+    // Can also do the validation operation above from a specification_map.
     std::vector<failure> validate(const Record& record) const {
         std::vector<failure> failures;
         for (const auto& [_, spec]: set_) {
@@ -1186,10 +1186,10 @@ private:
 };
 
 template <typename X>
-specification_set(X&) -> specification_set<typename value_type_t<X>::record_type>;
+specification_map(X&) -> specification_map<typename value_type_t<X>::record_type>;
 
 template <typename X>
-specification_set(X&, std::function<std::string (std::string_view)>) -> specification_set<typename value_type_t<X>::record_type>;
+specification_map(X&, std::function<std::string (std::string_view)>) -> specification_map<typename value_type_t<X>::record_type>;
 
 
 // V. Validation helpers
@@ -1308,7 +1308,7 @@ auto operator&=(V1 v1, V2 v2) {
 // or key/key-value records.
 
 template <typename Record>
-hopefully<void> import_k_eq_v(Record &rec, const specification_set<Record>& specs, const reader<std::string_view>& rdr,
+hopefully<void> import_k_eq_v(Record &rec, const specification_map<Record>& specs, const reader<std::string_view>& rdr,
                               std::string_view text, std::string eq_token = "=")
 {
     constexpr auto npos = std::string_view::npos;
@@ -1338,7 +1338,7 @@ hopefully<void> import_k_eq_v(Record &rec, const specification_set<Record>& spec
 
 
 template <typename Record>
-hopefully<void> import_k_eq_v(Record &rec, const specification_set<Record>& specs,
+hopefully<void> import_k_eq_v(Record &rec, const specification_map<Record>& specs,
                               std::string_view text, std::string eq_token = "=")
 {
     return import_k_eq_v(rec, specs, default_reader(), text, eq_token);
@@ -1446,7 +1446,7 @@ struct ini_style_importer {
 
     // Run run_once until eof or error.
     template <typename Record>
-    hopefully<void> run(Record& rec, const specification_set<Record>& specs,
+    hopefully<void> run(Record& rec, const specification_map<Record>& specs,
                         const reader<std::string_view>& rdr, std::string secsep = "/")
     {
         while (*this) {
@@ -1457,7 +1457,7 @@ struct ini_style_importer {
     }
 
     template <typename Record>
-    hopefully<void> run(Record& rec, const specification_set<Record>& specs, std::string secsep = "/") {
+    hopefully<void> run(Record& rec, const specification_map<Record>& specs, std::string secsep = "/") {
         return run(rec, specs, default_reader(), secsep);
     }
 
@@ -1468,7 +1468,7 @@ struct ini_style_importer {
     // Otherwise return a failure based on the current context.
 
     template <typename Record>
-    hopefully<ini_record_kind> run_one(Record& rec, const specification_set<Record>& specs,
+    hopefully<ini_record_kind> run_one(Record& rec, const specification_map<Record>& specs,
                                        const reader<std::string_view>& rdr, std::string secsep = "/")
     {
         separator_ = std::move(secsep);
@@ -1529,7 +1529,7 @@ struct ini_style_importer {
     }
 
     template <typename Record>
-    hopefully<ini_record_kind> run_one(Record& rec, const specification_set<Record>& specs, std::string secsep = "/") {
+    hopefully<ini_record_kind> run_one(Record& rec, const specification_map<Record>& specs, std::string secsep = "/") {
         return run_one(rec, specs, default_reader(), secsep);
     }
 
@@ -1545,13 +1545,13 @@ private:
 using ini_importer = ini_style_importer<simple_ini_parser>;
 
 template <typename Record>
-hopefully<void> import_ini(Record& rec, const specification_set<Record>& specs, const reader<std::string_view>& rdr,
+hopefully<void> import_ini(Record& rec, const specification_map<Record>& specs, const reader<std::string_view>& rdr,
                            std::istream& in, source_context ctx, std::string secsep = "/") {
     return ini_importer{in, std::move(ctx)}.run(rec, specs, rdr, secsep);
 }
 
 template <typename Record>
-hopefully<void> import_ini(Record& rec, const specification_set<Record>& specs, const reader<std::string_view>& rdr,
+hopefully<void> import_ini(Record& rec, const specification_map<Record>& specs, const reader<std::string_view>& rdr,
                            std::istream& in, std::string secsep = "/") {
     return ini_importer{in}.run(rec, specs, rdr, secsep);
 }


### PR DESCRIPTION
* Rename specification_set class to specification_map (which should be clearer) and update examples to suit.
* Update TODO.