### PR TITLE
Update googletest submodule to v1.17.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest
+	branch = 1.17.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest
-	branch = 1.17.0
+	branch = v1.17.x


### PR DESCRIPTION
* Set branch for googletest submodule to v1.17.x, checkout HEAD, matching v1.17.0 tag.

Fixes #12 