### PR TITLE
Fix read/write dsv with long delim.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 examples:=ex1 ex2 ex3 ex4 ex5 ex6 ex-defaulted ex-map-wrapper
 all:: unit $(examples) man
 
-test-src:=unit.cc test_failure.cc test_utility.cc test_reader.cc test_rw_helpers.cc test_defaulted.cc
+test-src:=unit.cc test_failure.cc test_utility.cc test_reader.cc test_rw_helpers.cc test_rw_defaults.cc test_defaulted.cc
 
 all-src:=$(test-src) $(patsubst %, %.cc, $(examples))
 all-obj:=$(patsubst %.cc, %.o, $(all-src))

--- a/include/parapara/parapara.h
+++ b/include/parapara/parapara.h
@@ -1013,7 +1013,7 @@ struct read_dsv {
             auto hf = read_field? read_field(f_repn): rdr.read<value_type>(f_repn);
             if (hf) {
                 fields.push_back(std::move(hf.value()));
-                if (d!=npos) v.remove_prefix(d+1);
+                if (d!=npos) v.remove_prefix(d+delim.length());
                 else break;
             }
             else {

--- a/test/test_rw_defaults.cc
+++ b/test/test_rw_defaults.cc
@@ -1,0 +1,81 @@
+#include <string>
+#include <string_view>
+#include <vector>
+#include <utility>
+#include <gtest/gtest.h>
+#include <parapara/parapara.h>
+
+using namespace parapara;
+using namespace std::literals;
+
+TEST(parapara, rw_dsv) {
+    using intvec = std::vector<int>;
+
+    // empty vector/representation
+    {
+        auto read_intvec = read_dsv<intvec>();
+        hopefully<intvec> hv = read_intvec(""sv, default_reader());
+
+        ASSERT_TRUE(hv);
+        EXPECT_TRUE(hv.value().empty());
+
+        auto write_intvec = write_dsv<intvec>();
+        hopefully<std::string> hs = write_intvec(intvec{}, default_writer());
+
+        ASSERT_TRUE(hs);
+        EXPECT_TRUE(hs.value().empty());
+    }
+
+    // unit vector/representation
+    {
+        auto read_intvec = read_dsv<intvec>();
+        hopefully<intvec> hv = read_intvec("123"sv, default_reader());
+
+        ASSERT_TRUE(hv);
+        ASSERT_EQ(1u, hv.value().size());
+        EXPECT_EQ(123, hv.value().at(0));
+
+        auto write_intvec = write_dsv<intvec>();
+        hopefully<std::string> hs = write_intvec(intvec{234}, default_writer());
+
+        ASSERT_TRUE(hs);
+        EXPECT_EQ("234"s, hs.value());
+    }
+
+    // longer vector/representation
+    {
+        // leading spaces should be removed with default parameter skip_ws = true.
+        auto read_intvec = read_dsv<intvec>();
+        hopefully<intvec> hv = read_intvec("123, 234, 345"sv, default_reader());
+
+        ASSERT_TRUE(hv);
+        ASSERT_EQ(3u, hv.value().size());
+        EXPECT_EQ(123, hv.value().at(0));
+        EXPECT_EQ(234, hv.value().at(1));
+        EXPECT_EQ(345, hv.value().at(2));
+
+        auto write_intvec = write_dsv<intvec>();
+        hopefully<std::string> hs = write_intvec(intvec{234, 345, 456}, default_writer());
+
+        ASSERT_TRUE(hs);
+        EXPECT_EQ("234,345,456"s, hs.value());
+    }
+
+    // vector with separator > 1 byte.
+    {
+        auto read_intvec = read_dsv<intvec>(u8"‡");
+        hopefully<intvec> hv = read_intvec("123‡234‡345"sv, default_reader());
+
+        ASSERT_TRUE(hv);
+        ASSERT_EQ(3u, hv.value().size());
+        EXPECT_EQ(123, hv.value().at(0));
+        EXPECT_EQ(234, hv.value().at(1));
+        EXPECT_EQ(345, hv.value().at(2));
+
+        auto write_intvec = write_dsv<intvec>(u8"‡");
+        hopefully<std::string> hs = write_intvec(intvec{234, 345, 456}, default_writer());
+
+        ASSERT_TRUE(hs);
+        EXPECT_EQ("234‡345‡456"s, hs.value());
+    }
+}


### PR DESCRIPTION
* Fix bug which assumed delimiters were always of length 1.
* Add unit tests for read_dsv, write_dsv.

Fixes #20